### PR TITLE
Get initial slot contents

### DIFF
--- a/packages/select/mdwc-select.js
+++ b/packages/select/mdwc-select.js
@@ -177,16 +177,23 @@ class Select extends LitElement {
       // TODO: dispatch value/change event?
     });
 
-    let slot = this.shadowRoot.querySelector('slot');
+    this.setSlotOptions(slot);
     slot.addEventListener('slotchange', (e) => {
-      this._options = slot.assignedElements()
-        .map((element) => {
-          return {
-            value: element.value,
-            label: element.innerHTML,
-          };
-        });
+     this.setSlotOptions(slot);
     });
+  }
+  
+  setSlotOptions(slot) {
+    let options = slot.assignedElements ? slot.assignedElements() : slot.assignedNodes().filter(node => {
+       return node.nodeType == Node.ELEMENT_NODE;
+     });
+     this._options = options
+       .map((element) => {
+         return {
+           value: element.value,
+           label: element.innerHTML,
+         };
+       });
   }
 
 


### PR DESCRIPTION
- the `slotchange` event doesn't run in Safari for the initial content, but you can use the initial elements from it, and it does fire on "real" update
- the `assignedElements` method is not defined in Safari, fallback to `assignedNodes` (similar, but not exactly the same)

There are still some issues:
- neither of the two methods, `assignedElements` or `assignedNodes` is available in Edge
- your `input` event is not triggered in FF from what I tested
- the value that comes there is **the previous one**, not the one you just selected